### PR TITLE
Внедрена система обратного проксирования

### DIFF
--- a/conf/conf.json
+++ b/conf/conf.json
@@ -1,4 +1,8 @@
 {
+    "client": {
+        "port":3000,
+        "host":"localhost"
+    },
     "server": {
         "port":8080,
         "host":"localhost"

--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -7,7 +7,7 @@ function send403(res) {
 }
 
 function restartAuth(res) {
-    return res.redirect('/auth');
+    return res.redirect('/auth/');
 }
 
 function startApp(res) {
@@ -32,9 +32,9 @@ function ensureAuthenticatedAPI(req, res, next) {
 // eslint-disable-next-line no-unused-vars
 function ensureAuthenticated(req, res, next) {
     if (!req.isAuthenticated || !req.isAuthenticated()) {
-        return res.redirect('/auth');
+        return restartAuth(res);
     } else {
-        return res.redirect('/feed');
+        return next();
     }
 }
 

--- a/libs/rproxy.js
+++ b/libs/rproxy.js
@@ -1,0 +1,13 @@
+
+var config = require('../conf');
+var httpProxy = require('http-proxy');
+
+var proxy = httpProxy.createProxyServer({});
+
+var clientServer = 'http://' +config.get('client:host')+ ':' + config.get('client:port');
+
+module.exports = function(req, res, next) {
+	// console.log('Redirected to client ');
+	proxy.web(req, res, {target: clientServer});
+};
+

--- a/main.js
+++ b/main.js
@@ -5,7 +5,7 @@ var app = express();
 var bodyParser = require('body-parser');
 var morgan = require('morgan');
 var session = require('express-session');
-var slashes = require('connect-slashes');
+// var slashes = require('connect-slashes');
 var router = require('./router');
 var passport = require('passport');
 var config = require('./conf');
@@ -16,6 +16,7 @@ if (process.env.NODE_ENV !== 'test') {
 }
 
 app
+    .disable('x-powered-by')
     .use(bodyParser.json())
     .use(bodyParser.urlencoded({extended: false}))
     .use(session({
@@ -32,13 +33,14 @@ app
         // })
     }))
     .use(passport.initialize())
-    .use(passport.session())
-    .use(slashes());
+    .use(passport.session());
+    // .use(slashes());
 
 router(app);
 
 app.listen(config.get('server:port'), function () {
     console.log('listening at %s:%s', config.get('server:host'), config.get('server:port'));
+    console.log('Proxyfing to %s:%s', config.get('client:host'), config.get('client:port'));
 });
 
 module.exports.app = app;

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "cookie-parser": "^1.4.1",
     "express": "^4.14.0",
     "express-session": "^1.14.0",
+    "http-proxy": "^1.14.0",
     "mongoose": "^4.5.8",
     "morgan": "^1.7.0",
     "nconf": "^0.8.4",

--- a/router.js
+++ b/router.js
@@ -4,14 +4,21 @@ var express = require('express');
 var apiRouter = express.Router();
 var commonRouter = express.Router();
 var controllers = require('./controllers');
+var rproxy = require('./libs/rproxy');
 
 commonRouter        // роутер для обычных путей аутентификации
-    .use(controllers.auth.ensureAuthenticated)
-    .get('/logout', controllers.auth.logout)
+    .get('/auth/', rproxy)
     .get('/auth/vk', controllers.auth.authVK)
     .get('/auth/vk/callback', controllers.auth.authVK)
     .get('/auth/fb', controllers.auth.authFB)
-    .get('/auth/fb/callback', controllers.auth.authFB);
+    .get('/auth/fb/callback', controllers.auth.authFB)
+    .get('/favicon.ico', rproxy)
+    .get(/\.js$|\.css$/, rproxy)
+    .use(controllers.auth.ensureAuthenticated)  // точка проверки аутентификации
+    .get('/logout', controllers.auth.logout)
+    .get('/feed/', rproxy)
+    .get('/feed', rproxy)
+    .get('/signup/', rproxy);
 
 apiRouter                                   // в этот роутер попадают только точки API, для них нужны:
     .use(controllers.auth.ensureAuthenticatedAPI) // обязательная проверка аутентификации пользователя


### PR DESCRIPTION
Для более удобного объединения и тестирования клиента и сервера.

Теперь для запуска системы нужно:
склонировать сервер и клиент (расположение не важно)
запустить как обычно клиент (на порту 3000)
запустить сервер (у него в конфиге должен быть указан порт 3000 клиента), 
сам сервер слушает порт 8080.
Для работы с системой можно открыть страницу: 
http://localhost:8080/
